### PR TITLE
feat: ability to use retrosocket without pairing

### DIFF
--- a/spring-retrosocket/src/main/java/org/springframework/retrosocket/RSocketClient.java
+++ b/spring-retrosocket/src/main/java/org/springframework/retrosocket/RSocketClient.java
@@ -10,5 +10,7 @@ import java.lang.annotation.*;
 @Documented
 @Inherited
 public @interface RSocketClient {
-
+  String  host() default "";
+  String  port() default "";
+  RequesterMode mode() default RequesterMode.PAIRING;
 }

--- a/spring-retrosocket/src/main/java/org/springframework/retrosocket/RSocketClientAutoConfiguration.java
+++ b/spring-retrosocket/src/main/java/org/springframework/retrosocket/RSocketClientAutoConfiguration.java
@@ -14,7 +14,6 @@ import org.springframework.messaging.rsocket.RSocketRequester;
 class RSocketClientAutoConfiguration {
 
 	@Bean
-	@ConditionalOnBean(RSocketRequester.class)
 	RSocketClientBuilder rSocketClientBuilder() {
 		return new RSocketClientBuilder();
 	}

--- a/spring-retrosocket/src/main/java/org/springframework/retrosocket/RSocketClientsRegistrar.java
+++ b/spring-retrosocket/src/main/java/org/springframework/retrosocket/RSocketClientsRegistrar.java
@@ -81,7 +81,9 @@ class RSocketClientsRegistrar implements BeanFactoryPostProcessor, ImportBeanDef
 				.forEach(beanDefinition -> {
 					AnnotationMetadata annotationMetadata = beanDefinition.getMetadata();
 					this.validateInterface(annotationMetadata);
-					this.registerRSocketClient(annotationMetadata, registry);
+					Map<String, Object> attributes = annotationMetadata
+							.getAnnotationAttributes(RSocketClient.class.getCanonicalName());
+					this.registerRSocketClient(annotationMetadata, registry, attributes);
 				}));
 	}
 
@@ -118,7 +120,8 @@ class RSocketClientsRegistrar implements BeanFactoryPostProcessor, ImportBeanDef
 	}
 
 	@SneakyThrows
-	private void registerRSocketClient(AnnotationMetadata annotationMetadata, BeanDefinitionRegistry registry) {
+	private void registerRSocketClient(AnnotationMetadata annotationMetadata,
+			BeanDefinitionRegistry registry, Map<String, Object> attributes) {
 		String className = annotationMetadata.getClassName();
 		if (log.isDebugEnabled()) {
 			log.debug("trying to turn the interface " + className + " into an RSocketClientFactoryBean");
@@ -126,6 +129,9 @@ class RSocketClientsRegistrar implements BeanFactoryPostProcessor, ImportBeanDef
 
 		BeanDefinitionBuilder definition = BeanDefinitionBuilder.genericBeanDefinition(RSocketClientFactoryBean.class);
 		definition.addPropertyValue("type", className);
+		definition.addPropertyValue("host", getHost(attributes));
+		definition.addPropertyValue("port", getAttribute(attributes, "port"));
+		definition.addPropertyValue("mode", getAttribute(attributes, "mode"));
 		definition.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_BY_TYPE);
 
 		AbstractBeanDefinition beanDefinition = definition.getBeanDefinition();
@@ -134,6 +140,21 @@ class RSocketClientsRegistrar implements BeanFactoryPostProcessor, ImportBeanDef
 
 		BeanDefinitionHolder holder = new BeanDefinitionHolder(beanDefinition, className, new String[0]);
 		BeanDefinitionReaderUtils.registerBeanDefinition(holder, registry);
+	}
+
+	private <T>T getAttribute(Map<String, Object> attributes, String name) {
+		return (T) attributes.get(name);
+	}
+
+	private String getHost(Map<String, Object> attributes) {
+		return resolve((String) attributes.get("host"));
+	}
+
+	private String resolve(String value) {
+		if (StringUtils.hasText(value)) {
+			return this.environment.resolvePlaceholders(value);
+		}
+		return value;
 	}
 
 	@Override

--- a/spring-retrosocket/src/main/java/org/springframework/retrosocket/RequesterMode.kt
+++ b/spring-retrosocket/src/main/java/org/springframework/retrosocket/RequesterMode.kt
@@ -1,0 +1,6 @@
+package org.springframework.retrosocket
+
+enum class RequesterMode {
+	PAIRING,
+	MANAGED
+}

--- a/spring-retrosocket/src/test/java/org/springframework/retrosocket/nopairing/GreetingClient.java
+++ b/spring-retrosocket/src/test/java/org/springframework/retrosocket/nopairing/GreetingClient.java
@@ -1,0 +1,37 @@
+package org.springframework.retrosocket.nopairing;
+
+import static org.springframework.retrosocket.RequesterMode.MANAGED;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.retrosocket.RSocketClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author <a href="mailto:josh@joshlong.com">Josh Long</a>
+ */
+@RSocketClient(host = "${greeting-client.host:localhost}", port = "${greeting-client.port:8888}", mode = MANAGED)
+interface GreetingClient {
+
+  @MessageMapping("greetings")
+  Mono<GreetingResponse> greet();
+
+  @MessageMapping("greetings-with-channel")
+  Flux<GreetingResponse> greetParams(Flux<String> names);
+
+  @MessageMapping("greetings-stream")
+  Flux<GreetingResponse> greetStream(Mono<String> name);
+
+  @MessageMapping("greetings-with-name")
+  Mono<GreetingResponse> greet(Mono<String> name);
+
+  @MessageMapping("fire-and-forget")
+  Mono<Void> greetFireAndForget(Mono<String> name);
+
+  @MessageMapping("greetings-mono-name.{name}.{age}")
+  Mono<String> greetMonoNameDestinationVariable(@DestinationVariable("name") String name,
+      @DestinationVariable("age") int age, @Payload Mono<String> payload);
+
+}

--- a/spring-retrosocket/src/test/java/org/springframework/retrosocket/nopairing/GreetingResponse.java
+++ b/spring-retrosocket/src/test/java/org/springframework/retrosocket/nopairing/GreetingResponse.java
@@ -1,0 +1,17 @@
+package org.springframework.retrosocket.nopairing;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author <a href="mailto:josh@joshlong.com">Josh Long</a>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GreetingResponse {
+
+	private String message;
+
+}

--- a/spring-retrosocket/src/test/java/org/springframework/retrosocket/nopairing/GreetingsController.java
+++ b/spring-retrosocket/src/test/java/org/springframework/retrosocket/nopairing/GreetingsController.java
@@ -1,0 +1,70 @@
+package org.springframework.retrosocket.nopairing;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import javax.annotation.PostConstruct;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.context.annotation.Profile;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Controller;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author <a href="mailto:josh@joshlong.com">Josh Long</a>
+ */
+@Log4j2
+@Profile("service")
+@Controller
+class GreetingsController {
+
+	static AtomicReference<String> fireAndForget = new AtomicReference<>();
+
+	@PostConstruct
+	public void begin() {
+		log.info("begin()");
+	}
+
+	@MessageMapping("greetings-mono-name.{name}.{age}")
+	Mono<String> greetMonoNameDestinationVariable(@DestinationVariable("name") String name,
+			@DestinationVariable("age") int age, @Payload Mono<String> payload) {
+		log.info("name=" + name);
+		log.info("age=" + age);
+		return payload;
+	}
+
+	@MessageMapping("fire-and-forget")
+	Mono<Void> fireAndForget(Mono<String> valueIn) {
+		return valueIn//
+				.doOnNext(value -> {
+					log.info("received fire-and-forget " + value + '.');
+					fireAndForget.set(value);
+				})//
+				.then();
+	}
+
+	@MessageMapping("greetings-with-channel")
+	Flux<GreetingResponse> greetParams(Flux<String> names) {
+		return names.map(String::toUpperCase).map(GreetingResponse::new);
+	}
+
+	@MessageMapping("greetings-stream")
+	Flux<GreetingResponse> greetFlux(Mono<String> name) {
+		return name.flatMapMany(
+				leNom -> Flux.fromStream(Stream.generate(() -> new GreetingResponse(leNom.toUpperCase()))).take(2));
+	}
+
+	@MessageMapping("greetings-with-name")
+	Mono<GreetingResponse> greetMono(Mono<String> name) {
+		return name.map(GreetingResponse::new);
+	}
+
+	@MessageMapping("greetings")
+	Mono<GreetingResponse> greet() {
+		log.info("invoking greetings and returning a GreetingsResponse.");
+		return Mono.just(new GreetingResponse("Hello, world!"));
+	}
+
+}

--- a/spring-retrosocket/src/test/java/org/springframework/retrosocket/nopairing/RSocketClientConfiguration.java
+++ b/spring-retrosocket/src/test/java/org/springframework/retrosocket/nopairing/RSocketClientConfiguration.java
@@ -1,0 +1,20 @@
+package org.springframework.retrosocket.nopairing;
+
+import javax.annotation.PostConstruct;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.messaging.rsocket.RSocketRequester;
+import org.springframework.retrosocket.EnableRSocketClients;
+
+/**
+ * @author <a href="mailto:josh@joshlong.com">Josh Long</a>
+ */
+@Log4j2
+@Profile("client")
+@EnableRSocketClients
+@SpringBootApplication
+class RSocketClientConfiguration {
+}

--- a/spring-retrosocket/src/test/java/org/springframework/retrosocket/nopairing/RSocketClientTest.java
+++ b/spring-retrosocket/src/test/java/org/springframework/retrosocket/nopairing/RSocketClientTest.java
@@ -1,0 +1,119 @@
+package org.springframework.retrosocket.nopairing;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.util.SocketUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * @author <a href="mailto:josh@joshlong.com">Josh Long</a>
+ */
+
+@Log4j2
+public class RSocketClientTest {
+
+	static ConfigurableApplicationContext serviceApplicationContext;
+
+	static AtomicInteger port = new AtomicInteger(7000);
+
+	@BeforeAll
+	public static void begin() {
+		serviceApplicationContext = new SpringApplicationBuilder(
+        RSocketServerConfiguration.class)//
+				.web(WebApplicationType.NONE)
+				.run("--spring.profiles.active=service", "--spring.rsocket.server.port=" + port.get());
+	}
+
+	@AfterAll
+	public static void destroy() {
+		serviceApplicationContext.stop();
+	}
+
+	@Test
+	public void destinationVariablesAndPayload() {
+		GreetingClient greetingClient = buildClient();
+		Mono<String> greetingResponseFlux = greetingClient.greetMonoNameDestinationVariable("jlong", 36,
+				Mono.just("Hello"));
+		StepVerifier//
+				.create(greetingResponseFlux)//
+				.expectNextMatches(gr -> gr.equalsIgnoreCase("Hello"))//
+				.verifyComplete();
+	}
+
+	@Test
+	public void monoInFluxOut() {
+		GreetingClient greetingClient = buildClient();
+		Flux<GreetingResponse> greetingResponseFlux = greetingClient.greetStream(Mono.just("a"));
+		StepVerifier//
+				.create(greetingResponseFlux)//
+				.expectNextCount(1).expectNextMatches(gr -> gr.getMessage().equalsIgnoreCase("A"))//
+				.verifyComplete();
+
+	}
+
+	@Test
+	public void fluxInFluxOut() {
+		GreetingClient greetingClient = buildClient();
+		Flux<GreetingResponse> greetingResponseFlux = greetingClient.greetParams(Flux.just("a", "b"));
+		StepVerifier//
+				.create(greetingResponseFlux)//
+				.expectNextMatches(gr -> gr.getMessage().equalsIgnoreCase("A"))//
+				.expectNextMatches(gr -> gr.getMessage().equalsIgnoreCase("B"))//
+				.verifyComplete();
+
+	}
+
+	@Test
+	public void monoInMonoOut() {
+		GreetingClient greetingClient = buildClient();
+		Mono<GreetingResponse> greet = greetingClient.greet(Mono.just("Hello, Mario"));
+		StepVerifier//
+				.create(greet)//
+				.expectNextMatches(gr -> gr.getMessage().equalsIgnoreCase("Hello, Mario"))//
+				.verifyComplete();
+
+	}
+
+	@Test
+	public void noValueInMonoOut() throws Exception {
+		GreetingClient greetingClient = buildClient();
+		Mono<GreetingResponse> greet = greetingClient.greet();
+		StepVerifier//
+				.create(greet)//
+				.expectNextMatches(gr -> gr.getMessage().equalsIgnoreCase("Hello, world!"))//
+				.verifyComplete();
+
+	}
+
+	@Test
+	public void fireAndForget() throws Exception {
+		GreetingClient greetingClient = buildClient();
+		String name = "Kimly";
+		Mono<Void> greet = greetingClient.greetFireAndForget(Mono.just(name));
+		StepVerifier//
+				.create(greet)//
+				.verifyComplete();
+
+		Thread.sleep(1000);
+		boolean kimly = GreetingsController.fireAndForget.get().equalsIgnoreCase(name);
+		Assertions.assertTrue(kimly, "the name perceived on the service is the same as we sent.");
+	}
+
+	private GreetingClient buildClient() {
+		ConfigurableApplicationContext context = new SpringApplicationBuilder(
+        RSocketClientConfiguration.class)//
+				.web(WebApplicationType.NONE)//
+				.run("--service.port=" + port.get(), "--spring.profiles.active=client" , "--greeting-client.port=" + port.get());
+		return context.getBean(GreetingClient.class);
+	}
+
+}

--- a/spring-retrosocket/src/test/java/org/springframework/retrosocket/nopairing/RSocketServerConfiguration.java
+++ b/spring-retrosocket/src/test/java/org/springframework/retrosocket/nopairing/RSocketServerConfiguration.java
@@ -1,0 +1,29 @@
+package org.springframework.retrosocket.nopairing;
+
+import javax.annotation.PostConstruct;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * @author <a href="mailto:josh@joshlong.com">Josh Long</a>
+ */
+@Log4j2
+@Profile("service")
+@Configuration
+@EnableAutoConfiguration
+class RSocketServerConfiguration {
+
+	@Bean
+  GreetingsController greetingsController() {
+		return new GreetingsController();
+	}
+
+	@PostConstruct
+	public void start() {
+		log.info("starting " + RSocketServerConfiguration.class.getName() + '.');
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: jpiraguha <jiraguha@gmail.com>

Hey @joshlong,

What if the `RSocketClientFactoryBean` could create a requester directly without pairing? The drawback is that we will need to provide on client config statically in `@RSocketClient` annotation but it would be closer to Feign experience!

ex: 

```
@RSocketClient(host = "${greeting-client.host:localhost}", port = "${greeting-client.port:8888}", mode = MANAGED)
```